### PR TITLE
Update to Dockerfile to fix SqlConnection not found

### DIFF
--- a/entityframework/Dockerfile
+++ b/entityframework/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y git curl
 RUN git clone https://github.com/aspnet/EntityFramework.Docs
 
 WORKDIR "EntityFramework.Docs/docs/getting-started/aspnet5/sample/src/EFGetStarted.AspNet5.ExistingDb"
-RUN ["dnu", "restore"]
+RUN [ "dnu", "restore", "--runtime", "ubuntu.14.04-x64" ]
 
 EXPOSE 5000
 ENTRYPOINT ["dnx", "web"]


### PR DESCRIPTION
"dnu restore is not properly honouring the DNX_RUNTIME_ID environment variable that we use to override the OS detection (since DNX technically only supports Ubuntu, but we use Debian)....
As a workaround though, you can get your scenario working by changing your dnu restore call to dnu restore --runtime ubuntu.14.04"
